### PR TITLE
fixed t/stack_trace.t fails on MSWin32.

### DIFF
--- a/t/stack_trace.t
+++ b/t/stack_trace.t
@@ -2,6 +2,7 @@
 use warnings;
 use strict;
 use Test::More tests => 4;
+use File::Spec;
 
 {
     package Foo;
@@ -38,8 +39,9 @@ catch {
     like $_->error, qr/suspended/, 'stringified error contains twitter error message';
     
     my $frame = $_->stack_trace->frame(0);
-    my $file = __FILE__;
-    is $frame->{filename}, $file, "first stack frame file";
+    my $file = File::Spec->canonpath(__FILE__);
+    my $file_in_frame = File::Spec->canonpath($frame->{filename});
+    is $file_in_frame, $file, "first stack frame file";
     is $frame->{line}, $line, "first stack frame line";
-    like $_->error, qr( at $file line $line$), 'error contains first stack frame';
+    like $_->error, qr( at \Q$file\E line $line$), 'error contains first stack frame';
 };


### PR DESCRIPTION
I've fixed -- t/stack_trace.t fails on MSWin32 because of difference of path-separator.
- the file name from __FILE__ on t/stack_trace.t expanded to 't\stack_trace.t' on MSWin32-perl
  but another in stack frame from Try::Tiny is 't/stack_trace.t'.
  I think this is case to use File::Spec to absorb difference of path-separator.
- one more, I think file names (especially with windows-style path-separator) should be quoted in regex, don't you?
