### PR TITLE
Adds required version for Devel::StackTrace prereq

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,7 @@ requires    'Crypt::SSLeay'             => 0.50;
 requires    'Data::Visitor::Callback';
 requires    'DateTime'                  => 0.51;
 requires    'DateTime::Format::Strptime'=> 1.09;
-requires    'Devel::StackTrace';
+requires    'Devel::StackTrace'         => 1.21;
 requires    'Encode';
 requires    'HTML::Entities';
 requires    'HTTP::Request::Common';


### PR DESCRIPTION
Net::Twitter::Error uses Devel::StackTrace's frame_filter option, which was added in 1.21.
