### PR TITLE
obsolate parameters for friendships_exists

### DIFF
--- a/lib/Net/Twitter/Role/API/REST.pm
+++ b/lib/Net/Twitter/Role/API/REST.pm
@@ -436,8 +436,8 @@ user_a follows user_b, otherwise will return false.
 
     path     => 'friendships/exists',
     method   => 'GET',
-    params   => [qw/user_a user_b/],
-    required => [qw/user_a user_b/],
+    params   => [qw/user_id_a user_id_b screen_name_a screen_name_b/],
+    required => [],
     returns  => 'Bool',
 );
 


### PR DESCRIPTION
For friendships_exists,
the parameters user_a and user_b are still accepted
but not recommended. As a sequence of numbers is a
valid screen name it is recommend to use the screen_name
or user_id variant style parameters instead.

it it is used with user_a and user_b as bellow,
$nt->friendship_exists({ user_a => $fred, user_b => $barney });
both $fred and $barney are handled as screen_name.

https://dev.twitter.com/docs/api/1/get/friendships/exists
