### PR TITLE
AutoCursors POD changes

### DIFF
--- a/lib/Net/Twitter/Role/AutoCursor.pm
+++ b/lib/Net/Twitter/Role/AutoCursor.pm
@@ -68,7 +68,7 @@ Net::Twitter::Role::AutoCursor - Help transition to cursor based access to frien
 =head1 SYNOPSIS
 
   use Net::Twitter;
-  # Get friends_ids or followers_ids without worrying about cursors
+  # Get friends or followers without worrying about cursors
   my $nt = Net::Twitter->new(
       traits => [
           qw/API::REST RetryOnError OAuth/


### PR DESCRIPTION
Updated POD to make the example work right off the bat. I'd suggest setting force_cursor by default to 1, as the current setting of '0' doesn't do anything when followers or following are called.
