### PR TITLE
Permit PUT as an HTTP method

### DIFF
--- a/lib/Net/Twitter/Core.pm
+++ b/lib/Net/Twitter/Core.pm
@@ -158,7 +158,7 @@ sub _prepare_request {
 
     $self->_encode_args(\%natural_args);
 
-    if ( $http_method =~ /^(?:GET|DELETE)$/ ) {
+    if ( $http_method =~ /^(?:GET|DELETE|PUT)$/ ) {
         $uri->query($self->_query_string_for(\%natural_args));
         $msg = HTTP::Request->new($http_method, $uri);
     }


### PR DESCRIPTION
`HTTP::Request::Common` suggests that `PUT` is just like `GET` and `DELETE`:

```
sub GET  { _simple_req('GET',  @_); }
sub HEAD { _simple_req('HEAD', @_); }
sub PUT  { _simple_req('PUT' , @_); }
sub DELETE { _simple_req('DELETE', @_); }
```

I guess we could at `HEAD` too, but, eh, I actually need `PUT`. :)
