### PR TITLE
Fix grammar within ./examples/oauth_desktop.pl

### DIFF
--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -30,10 +30,11 @@ if ( @$access_tokens ) {
 }
 else {
     my $auth_url = $nt->get_authorization_url;
-    print "Authorize this application at: $auth_url\nThen, enter the PIN# provided to continue: ";
+    print "\n1. Authorize the Twitter App at: $auth_url\n2. Enter the returned PIN to complete the Twitter App authorization process: ";
 
     my $pin = <STDIN>; # wait for input
     chomp $pin;
+    print "\n";
 
     # request_access_token stores the tokens in $nt AND returns them
     my @access_tokens = $nt->request_access_token(verifier => $pin);
@@ -44,3 +45,4 @@ else {
 
 my $status = $nt->user_timeline({ count => 1 });
 print Dumper $status;
+print "\n";


### PR DESCRIPTION
Fix for the following two issues on [line #33 of /examples/oauth_desktop.pl](https://github.com/semifor/Net-Twitter/blob/master/examples/oauth_desktop.pl#L33)
1. Removed the space character before "Authorize ..." and;
2. Corrected "... continue: " word spelling.

Please let me know if you prefer that I submit Pull Request(s) from a new topic branch too?
