### PR TITLE
Feature Smart::Comments

### DIFF
--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -10,6 +10,10 @@ use File::Spec;
 use Storable;
 use Data::Dumper;
 
+# #CONFIGURATION Remove "#" for Smart::Comments
+# use Smart::Comments;
+
+
 # You can replace the consumer tokens with your own;
 # these tokens are for the Net::Twitter example app.
 my %consumer_tokens = (
@@ -43,6 +47,22 @@ else {
     store \@access_tokens, $datafile;
 }
 
-my $status = $nt->user_timeline({ count => 1 });
-print Dumper $status;
+my $statuses_ref = $nt->user_timeline({ count => 1 });
+print Dumper $statuses_ref;
 print "\n";
+
+my @statuses = @{$statuses_ref};
+my $statuses_count = $statuses[0]->{user}{statuses_count};
+
+# "###" is for Smart::Comments CPAN Module
+### \$statuses_count is: $statuses_count
+
+my $max_id = $statuses[0]->{id_str};
+
+# "###" is for Smart::Comments CPAN Module
+### \$max_id is: $max_id
+
+print "\n";
+
+
+


### PR DESCRIPTION
I renamed $status to $statuses_ref to reflect [Perl Best Practices](http://shop.oreilly.com/product/9780596001735.do)

I have also incorporated the [Smart::Comments CPAN Module](http://search.cpan.org/~chorny/Smart-Comments-1.0.4/lib/Smart/Comments.pm) which can be enabled by removing the "#" characters at the beginning of the line below:

```
# use Smart::Comments;
```

The [Smart::Comments CPAN Module](http://search.cpan.org/~chorny/Smart-Comments-1.0.4/lib/Smart/Comments.pm) will print similar text (i.e. the example quoted below is specific to my [twitter account](https://twitter.com/cmlh)) to STDERR: 

```
### \$statuses_count is: 4023

### \$max_id is: '345706738261037056'
```

The next stage is to create a sub() to traverse the last 3200 tweets from timeline.

Please let me know if you prefer to receive pull requests from a topic branch instead of Master? 
