### PR TITLE
Progress (July-August 2013) on oauth_desktop.pl

### DIFF
--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -11,6 +11,7 @@ use File::Spec;
 use Storable;
 use Getopt::Long;
 use Data::Dumper;
+use Term::ANSIColor;
 
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments;
@@ -53,6 +54,9 @@ if ($update eq 1) {
 	print "Please execute \"git fetch git://github.com/cmlh/Net-Twitter.git\" from the command line\n";
 	die();
 }
+
+print color("green"), "Retrieving $screen_name tweets.\n\n";
+print color("reset");
 
 # "###" is for Smart::Comments CPAN Module
 ### \$screen_name is: $screen_name;

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -64,6 +64,7 @@ if ( $update eq 1 ) {
     die();
 }
 
+# TODO Confirm that -screen_name does exist on Twitter
 # TODO insert $statuses_count i.e. $statuses[0]->{user}{statuses_count}
 print "Retrieving $screen_name tweets.\n\n";
 
@@ -110,6 +111,9 @@ else {
     store \@access_tokens, $datafile;
 }
 
+# TODO https://dev.twitter.com/docs/rate-limiting, has dependency on either
+# https://github.com/semifor/Net-Twitter/pull/32 or 
+# https://github.com/semifor/Net-Twitter/pull/31
 my $statuses_ref =
   $nt->user_timeline( { count => 1, screen_name => $screen_name } );
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -10,6 +10,10 @@ use File::Spec;
 use Storable;
 use Data::Dumper;
 
+# #CONFIGURATION Remove "#" for Smart::Comments
+# use Smart::Comments;
+
+
 # You can replace the consumer tokens with your own;
 # these tokens are for the Net::Twitter example app.
 my %consumer_tokens = (
@@ -43,6 +47,22 @@ else {
     store \@access_tokens, $datafile;
 }
 
-my $status = $nt->user_timeline({ count => 1 });
-print Dumper $status;
+my $statuses_ref = $nt->user_timeline({ count => 1 });
+print Dumper $statuses_ref;
 print "\n";
+
+my @statuses = @{$statuses_ref};
+my $statuses_count = $statuses[0]->{user}{statuses_count};
+
+# "###" is for Smart::Comments CPAN Module
+### \$statuses_count is: $statuses_count
+
+my $max_id = $statuses[0]->{id_str};
+
+# "###" is for Smart::Comments CPAN Module
+### \$max_id is: $max_id
+
+print "\n";
+
+
+

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -15,7 +15,7 @@ use Data::Dumper;
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments;
 
-my $VERSION = '1.0.0';
+my $VERSION = '1.0.1';
 
 # Command line arguements
 my $screen_name = "cmlh";
@@ -119,6 +119,9 @@ my $max_id = $statuses[0]->{id_str};
 print "\n";
 
 my $count = 200;
+my $contributor_details = 1; # true
+my $include_rts = 1; # true
+
 
 open (TIMELINE_DUMPER, ">>", "$screen_name" . "_dumper.txt");
 
@@ -126,7 +129,7 @@ open (TIMELINE_DUMPER, ">>", "$screen_name" . "_dumper.txt");
 if ($statuses_count >= $count) {
 	while ($statuses_count > $count) {
 		# TODO Refactor as sub()
-		$statuses_ref = $nt->user_timeline({ count => $count, max_id => $max_id, screen_name => $screen_name });
+		$statuses_ref = $nt->user_timeline({ count => $count, max_id => $max_id, screen_name => $screen_name, contributor_details => $contributor_details, include_rts => $include_rts });
 		# print Dumper $statuses_ref;
 		print TIMELINE_DUMPER (Data::Dumper::Dumper($statuses_ref));
 		foreach my $status (@$statuses_ref) {
@@ -146,7 +149,7 @@ if ($statuses_count != 0) {
 	# TODO Refactor as sub()
 	# "###" is for Smart::Comments CPAN Module
 	### \$count is: $count
-	$statuses_ref = $nt->user_timeline({ count => $count, max_id => $max_id, screen_name => $screen_name });
+	$statuses_ref = $nt->user_timeline({ count => $count, max_id => $max_id, screen_name => $screen_name, contributor_details => $contributor_details, include_rts => $include_rts });
 	# print Dumper $statuses_ref;
 	print TIMELINE_DUMPER (Data::Dumper::Dumper($statuses_ref));
 	foreach my $status (@$statuses_ref) {

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -15,6 +15,8 @@ use Data::Dumper;
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments;
 
+my $VERSION = '1.0.0';
+
 # Command line arguements
 my $screen_name = "cmlh";
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -13,6 +13,10 @@ use Data::Dumper;
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments;
 
+# TODO Refactor with Getopt::Long CPAN Module
+# https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline
+# #CONFIGURATION $screen_name is https://twitter.com/[INSERT screen_name]
+my $screen_name = "cmlh";
 
 # You can replace the consumer tokens with your own;
 # these tokens are for the Net::Twitter example app.
@@ -47,8 +51,8 @@ else {
     store \@access_tokens, $datafile;
 }
 
-my $statuses_ref = $nt->user_timeline({ count => 1 });
-print Dumper $statuses_ref;
+my $statuses_ref = $nt->user_timeline({ count => 1, screen_name => $screen_name });
+# print Dumper $statuses_ref;
 print "\n";
 
 my @statuses = @{$statuses_ref};
@@ -57,12 +61,64 @@ my $statuses_count = $statuses[0]->{user}{statuses_count};
 # "###" is for Smart::Comments CPAN Module
 ### \$statuses_count is: $statuses_count
 
-my $max_id = $statuses[0]->{id_str};
+# "...return up to 3,200 of a user's most recent Tweets." quoted from https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline
+my $twitter_api_v1_1_tweet_total = 3200;
+
+if ($statuses_count > $twitter_api_v1_1_tweet_total) {
+	# "###" is for Smart::Comments CPAN Module
+	### Reduced \$statuses_count to 3200
+	$statuses_count = $twitter_api_v1_1_tweet_total;
+}
 
 # "###" is for Smart::Comments CPAN Module
-### \$max_id is: $max_id
+### \$statuses_count is: $statuses_count
+
+my $max_id = $statuses[0]->{id_str};
+
+# "####" is for Smart::Comments CPAN Module
+#### \$max_id is: $max_id
 
 print "\n";
 
+my $count = 200;
 
+open (TIMELINE_DUMPER, ">>", "$screen_name" . "_dumper.txt");
 
+# Timeline is less than 200 tweets
+if ($statuses_count >= $count) {
+	while ($statuses_count > $count) {
+		# TODO Refactor as sub()
+		$statuses_ref = $nt->user_timeline({ count => $count, max_id => $max_id, screen_name => $screen_name });
+		# print Dumper $statuses_ref;
+		print TIMELINE_DUMPER (Data::Dumper::Dumper($statuses_ref));
+		foreach my $status (@$statuses_ref) {
+			$max_id = $status->{id_str};
+			# "####" is for Smart::Comments CPAN Module
+			#### \$max_id is: $max_id
+		}
+		# "####" is for Smart::Comments CPAN Module
+		#### \$max_id is: $max_id
+		$statuses_count = $statuses_count - $count; 
+		# "###" is for Smart::Comments CPAN Module
+		### \$statuses_count is: $statuses_count
+	}
+}
+
+if ($statuses_count != 0) {
+	# TODO Refactor as sub()
+	# "###" is for Smart::Comments CPAN Module
+	### \$count is: $count
+	$statuses_ref = $nt->user_timeline({ count => $count, max_id => $max_id, screen_name => $screen_name });
+	# print Dumper $statuses_ref;
+	print TIMELINE_DUMPER (Data::Dumper::Dumper($statuses_ref));
+	foreach my $status (@$statuses_ref) {
+		$max_id = $status->{id_str};
+		# "####" is for Smart::Comments CPAN Module
+		#### \$max_id is: $max_id
+	}
+	# "####" is for Smart::Comments CPAN Module
+	#### \$max_id is: $max_id
+	$statuses_count = $statuses_count - $count; 
+	# "###" is for Smart::Comments CPAN Module
+	### \$statuses_count is: $statuses_count
+}

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -6,17 +6,48 @@ use warnings;
 use strict;
 
 use Net::Twitter;
+use Pod::Usage;
 use File::Spec;
 use Storable;
+use Getopt::Long;
 use Data::Dumper;
 
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments;
 
-# TODO Refactor with Getopt::Long CPAN Module
-# https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline
-# #CONFIGURATION $screen_name is https://twitter.com/[INSERT screen_name]
+# Command line arguements
 my $screen_name = "cmlh";
+
+# Command line meta-options
+my $usage = 0;
+my $man = 0;
+my $update = 0;
+
+# TODO Display -usage if command line argument(s) are incorrect
+GetOptions(
+	# https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline
+    "screen_name=s" => \$screen_name,
+
+# Command line meta-options
+# -version is excluded as it is printed prior to processing the command line arguments
+# TODO -verbose
+    "usage" => \$usage,
+    "man"   => \$man,
+	"update"  => \$update
+);
+
+if ( ( $usage eq 1 ) or ( $man eq 1 ) ) {
+    pod2usage( -verbose => 2 );
+    die();
+}
+
+if ($update eq 1) {
+	print "Please execute \"git fetch git://github.com/cmlh/Net-Twitter.git\" from the command line\n";
+	die();
+}
+
+# "###" is for Smart::Comments CPAN Module
+### \$screen_name is: $screen_name;
 
 # You can replace the consumer tokens with your own;
 # these tokens are for the Net::Twitter example app.

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -11,7 +11,6 @@ use File::Spec;
 use Storable;
 use Getopt::Long;
 use Data::Dumper;
-use Term::ANSIColor;
 
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments '####','###';
@@ -20,7 +19,7 @@ use Term::ANSIColor;
 #### [<time>] oauth_desktop.pl start
 
 
-my $VERSION = "0.001";
+my $VERSION = "0.001_1";
 $VERSION = eval $VERSION;
 
 print "\n\"oauth_desktop\" Alpha v$VERSION\n";
@@ -61,8 +60,7 @@ if ( $update eq 1 ) {
     die();
 }
 
-print color("green"), "Retrieving $screen_name tweets.\n\n";
-print color("reset");
+print "Retrieving $screen_name tweets.\n\n";
 
 # "####" is for Smart::Comments CPAN Module
 #### \$screen_name is: $screen_name;

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -96,6 +96,7 @@ else {
     print "\n";
 
     # request_access_token stores the tokens in $nt AND returns them
+    # TODO Raise an exception if $pin is incorrect
     my @access_tokens = $nt->request_access_token( verifier => $pin );
 
     # save the access tokens

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -16,6 +16,7 @@ use YAML::XS; # TODO Refactor with YAML::Tiny
 
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments '####','###';
+# TODO Refactor Smart::Comments -ENV i.e. http://search.cpan.org/~dconway/Smart-Comments-1.000005/lib/Smart/Comments.pm#CONFIGURATION_AND_ENVIRONMENT
 
 # "####" is for Smart::Comments CPAN Module
 #### [<time>] oauth_desktop.pl start
@@ -62,6 +63,7 @@ if ( $update eq 1 ) {
     die();
 }
 
+# TODO insert $statuses_count i.e. $statuses[0]->{user}{statuses_count}
 print "Retrieving $screen_name tweets.\n\n";
 
 # "####" is for Smart::Comments CPAN Module
@@ -143,6 +145,7 @@ open( TIMELINE_YAML_DUMPER, ">>", "$screen_name" . "_dumper.yml" );
 
 # Timeline is less than 200 tweets
 if ( $statuses_count >= $count ) {
+	# TODO Display Progress Bar
     while ( $statuses_count > $count ) {
 
         # TODO Refactor as sub()

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -2,12 +2,9 @@
 # The above shebang is for "perlbrew", otherwise use /usr/bin/perl or the file path quoted for "which perl"
 #
 # Please refer to the Plain Old Documentation (POD) at the end of this Perl Script for further information
-#
-# Net::Twitter - OAuth desktop app example
-#
+
 use warnings;
 use strict;
-
 use Net::Twitter;
 use Pod::Usage;
 use File::Spec;
@@ -161,3 +158,96 @@ if ($statuses_count != 0) {
 	# "###" is for Smart::Comments CPAN Module
 	### \$statuses_count is: $statuses_count
 }
+
+=head1 NAME
+
+oauth_desktop.pl
+
+=head1 VERSION
+
+This documentation refers to oauth_desktop $VERSION
+
+=head1 CONFIGURATION
+
+Set the value(s) marked as #CONFIGURATION above this POD
+    
+=head1 USAGE
+
+oauth_desktop.pl [-screen_name] [screen name]
+
+=head1 REQUIRED ARGUEMENTS
+
+=head2 Command Line
+
+-screen_name [screen_name]
+                
+=head1 OPTIONAL ARGUEMENTS
+
+-man       Displays POD and exits.
+-usage     Displays POD and exits.
+-update    Displays the Team Explorer command to retrieve the latest update from codeplex.com
+
+=head1 DESCRIPTION
+
+"oauth_desktop.pl" leverages the Twitter API v1.1 to archive the last 3200 tweets of a screen name.
+
+Based on "Net::Twitter - OAuth desktop app example" from Marc Mims.
+
+=head1 DEPENDENCIES
+
+=head1 PREREQUISITES
+
+TODO
+
+=head1 COREQUISITES
+
+=head1 INSTALLATION
+
+=head1 OSNAMES
+
+osx
+
+=head1 SCRIPT CATEGORIES
+
+Web
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+Please refer to the comments beginning with "TODO" in the Perl Code.
+
+=head1 AUTHOR
+
+Christian Heinrich
+Marc Mims
+
+=head1 CONTACT INFORMATION
+
+http://cmlh.id.au/contact
+
+=head1 MAILING LIST
+
+=head1 REPOSITORY
+
+https://github.com/cmlh/Net-Twitter forked from https://github.com/semifor/Net-Twitter
+
+=head1 FURTHER INFORMATION AND UPDATES
+
+http://del.icio.us/cmlh/Twitter
+
+=head1 LICENSE AND COPYRIGHT
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. 
+
+Copyright 2013 Christian Heinrich

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -11,6 +11,8 @@ use File::Spec;
 use Storable;
 use Getopt::Long;
 use Data::Dumper;
+use YAML::XS; # TODO Refactor with YAML::Tiny
+# use utf8; applied within YAML::XS 
 
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments '####','###';
@@ -19,7 +21,7 @@ use Data::Dumper;
 #### [<time>] oauth_desktop.pl start
 
 
-my $VERSION = "0.001_1";
+my $VERSION = "0.001_2";
 $VERSION = eval $VERSION;
 
 print "\n\"oauth_desktop\" Alpha v$VERSION\n";
@@ -136,7 +138,8 @@ my $count               = 200;
 my $contributor_details = 1;     # true
 my $include_rts         = 1;     # true
 
-open( TIMELINE_DUMPER, ">>", "$screen_name" . "_dumper.txt" );
+open( TIMELINE_DATA_DUMPER, ">>", "$screen_name" . "_dumper.txt" );
+open( TIMELINE_YAML_DUMPER, ">>", "$screen_name" . "_dumper.yml" );
 
 # Timeline is less than 200 tweets
 if ( $statuses_count >= $count ) {
@@ -156,7 +159,9 @@ if ( $statuses_count >= $count ) {
         @statuses       = @{$statuses_ref};
 
         my $data_dumper = Data::Dumper->new([\@statuses], [qw (statuses)]);
-        print TIMELINE_DUMPER ( $data_dumper->Dump);
+        print TIMELINE_DATA_DUMPER ( $data_dumper->Dump);
+        my $yaml_dumper = Dump @statuses;
+        print TIMELINE_YAML_DUMPER ( $yaml_dumper );
         foreach my $status (@$statuses_ref) {
             $max_id = $status->{id_str};
 
@@ -192,7 +197,10 @@ if ( $statuses_count != 0 ) {
     @statuses       = @{$statuses_ref};
 
     my $data_dumper = Data::Dumper->new([\@statuses], [qw (statuses)]);
-    print TIMELINE_DUMPER ( $data_dumper->Dump);
+    print TIMELINE_DATA_DUMPER ( $data_dumper->Dump);
+    my $yaml_dumper = Dump @statuses;
+    print TIMELINE_YAML_DUMPER ( $yaml_dumper );
+    
     foreach my $status (@$statuses_ref) {
         $max_id = $status->{id_str};
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -14,7 +14,11 @@ use Data::Dumper;
 use Term::ANSIColor;
 
 # #CONFIGURATION Remove "#" for Smart::Comments
-# use Smart::Comments;
+# use Smart::Comments '####','###';
+
+# "####" is for Smart::Comments CPAN Module
+#### [<time>] oauth_desktop.pl start
+
 
 my $VERSION = "0.001";
 $VERSION = eval $VERSION;
@@ -60,8 +64,8 @@ if ( $update eq 1 ) {
 print color("green"), "Retrieving $screen_name tweets.\n\n";
 print color("reset");
 
-# "###" is for Smart::Comments CPAN Module
-### \$screen_name is: $screen_name;
+# "####" is for Smart::Comments CPAN Module
+#### \$screen_name is: $screen_name;
 
 # You can replace the consumer tokens with your own;
 # these tokens are for the Net::Twitter example app.
@@ -109,8 +113,8 @@ my $statuses_ref =
 my @statuses       = @{$statuses_ref};
 my $statuses_count = $statuses[0]->{user}{statuses_count};
 
-# "###" is for Smart::Comments CPAN Module
-### \$statuses_count is: $statuses_count
+# "####" is for Smart::Comments CPAN Module
+#### \$statuses_count is: $statuses_count
 
 # "...return up to 3,200 of a user's most recent Tweets." quoted from https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline
 my $twitter_api_v1_1_tweet_total = 3200;
@@ -122,8 +126,8 @@ if ( $statuses_count > $twitter_api_v1_1_tweet_total ) {
     $statuses_count = $twitter_api_v1_1_tweet_total;
 }
 
-# "###" is for Smart::Comments CPAN Module
-### \$statuses_count is: $statuses_count
+# "####" is for Smart::Comments CPAN Module
+#### \$statuses_count is: $statuses_count
 
 my $max_id = $statuses[0]->{id_str};
 
@@ -164,18 +168,19 @@ if ( $statuses_count >= $count ) {
 
         # "####" is for Smart::Comments CPAN Module
         #### \$max_id is: $max_id
+        
         $statuses_count = $statuses_count - $count;
 
-        # "###" is for Smart::Comments CPAN Module
-        ### \$statuses_count is: $statuses_count
+        # "####" is for Smart::Comments CPAN Module
+        #### \$statuses_count is: $statuses_count
     }
 }
 
 if ( $statuses_count != 0 ) {
 
     # TODO Refactor as sub()
-    # "###" is for Smart::Comments CPAN Module
-    ### \$count is: $count
+    # "####" is for Smart::Comments CPAN Module
+    #### \$count is: $count
     $statuses_ref = $nt->user_timeline(
         {
             count               => $count,
@@ -201,9 +206,11 @@ if ( $statuses_count != 0 ) {
     #### \$max_id is: $max_id
     $statuses_count = $statuses_count - $count;
 
-    # "###" is for Smart::Comments CPAN Module
-    ### \$statuses_count is: $statuses_count
+    # "####" is for Smart::Comments CPAN Module
+    #### \$statuses_count is: $statuses_count
 }
+
+#### [<time>] oauth_desktop.pl finsh
 
 =head1 NAME
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -106,8 +106,6 @@ else {
 my $statuses_ref =
   $nt->user_timeline( { count => 1, screen_name => $screen_name } );
 
-print "\n";
-
 my @statuses       = @{$statuses_ref};
 my $statuses_count = $statuses[0]->{user}{statuses_count};
 
@@ -131,8 +129,6 @@ my $max_id = $statuses[0]->{id_str};
 
 # "####" is for Smart::Comments CPAN Module
 #### \$max_id is: $max_id
-
-print "\n";
 
 my $count               = 200;
 my $contributor_details = 1;     # true

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -23,7 +23,7 @@ use YAML::XS;    # TODO Refactor with YAML::Tiny
 # "####" is for Smart::Comments CPAN Module
 #### [<time>] oauth_desktop.pl start
 
-my $VERSION = "0.001_2";
+my $VERSION = "0.001_3";
 $VERSION = eval $VERSION;
 
 print "\n\"oauth_desktop\" Alpha v$VERSION\n";
@@ -83,7 +83,7 @@ my %consumer_tokens = (
 my ( undef, undef, $datafile ) = File::Spec->splitpath($0);
 $datafile =~ s/\..*/.dat/;
 
-my $nt = Net::Twitter->new( traits => [qw/API::RESTv1_1/], %consumer_tokens );
+my $nt = Net::Twitter->new( traits => [qw/API::RESTv1_1/], %consumer_tokens, ssl => 1, );
 
 # my $ua = $nt->ua;
 # 127.0.0.1:8080 for http://portswigger.net/burp/help/proxy_using.html

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -11,8 +11,9 @@ use File::Spec;
 use Storable;
 use Getopt::Long;
 use Data::Dumper;
-use YAML::XS; # TODO Refactor with YAML::Tiny
-# use utf8; applied within YAML::XS 
+use YAML::XS;    # TODO Refactor with YAML::Tiny
+
+# use utf8; applied within YAML::XS
 
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments '####','###';
@@ -20,7 +21,6 @@ use YAML::XS; # TODO Refactor with YAML::Tiny
 
 # "####" is for Smart::Comments CPAN Module
 #### [<time>] oauth_desktop.pl start
-
 
 my $VERSION = "0.001_2";
 $VERSION = eval $VERSION;
@@ -145,7 +145,8 @@ open( TIMELINE_YAML_DUMPER, ">>", "$screen_name" . "_dumper.yml" );
 
 # Timeline is less than 200 tweets
 if ( $statuses_count >= $count ) {
-	# TODO Display Progress Bar
+
+    # TODO Display Progress Bar
     while ( $statuses_count > $count ) {
 
         # TODO Refactor as sub()
@@ -158,13 +159,13 @@ if ( $statuses_count >= $count ) {
                 include_rts         => $include_rts
             }
         );
-        
-        @statuses       = @{$statuses_ref};
 
-        my $data_dumper = Data::Dumper->new([\@statuses], [qw (statuses)]);
-        print TIMELINE_DATA_DUMPER ( $data_dumper->Dump);
+        @statuses = @{$statuses_ref};
+
+        my $data_dumper = Data::Dumper->new( [ \@statuses ], [qw (statuses)] );
+        print TIMELINE_DATA_DUMPER ( $data_dumper->Dump );
         my $yaml_dumper = Dump @statuses;
-        print TIMELINE_YAML_DUMPER ( $yaml_dumper );
+        print TIMELINE_YAML_DUMPER ($yaml_dumper);
         foreach my $status (@$statuses_ref) {
             $max_id = $status->{id_str};
 
@@ -174,7 +175,7 @@ if ( $statuses_count >= $count ) {
 
         # "####" is for Smart::Comments CPAN Module
         #### \$max_id is: $max_id
-        
+
         $statuses_count = $statuses_count - $count;
 
         # "####" is for Smart::Comments CPAN Module
@@ -196,14 +197,14 @@ if ( $statuses_count != 0 ) {
             include_rts         => $include_rts
         }
     );
-    
-    @statuses       = @{$statuses_ref};
 
-    my $data_dumper = Data::Dumper->new([\@statuses], [qw (statuses)]);
-    print TIMELINE_DATA_DUMPER ( $data_dumper->Dump);
+    @statuses = @{$statuses_ref};
+
+    my $data_dumper = Data::Dumper->new( [ \@statuses ], [qw (statuses)] );
+    print TIMELINE_DATA_DUMPER ( $data_dumper->Dump );
     my $yaml_dumper = Dump @statuses;
-    print TIMELINE_YAML_DUMPER ( $yaml_dumper );
-    
+    print TIMELINE_YAML_DUMPER ($yaml_dumper);
+
     foreach my $status (@$statuses_ref) {
         $max_id = $status->{id_str};
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -106,7 +106,6 @@ else {
 my $statuses_ref =
   $nt->user_timeline( { count => 1, screen_name => $screen_name } );
 
-# print Dumper $statuses_ref;
 print "\n";
 
 my @statuses       = @{$statuses_ref};
@@ -155,9 +154,11 @@ if ( $statuses_count >= $count ) {
                 include_rts         => $include_rts
             }
         );
+        
+        @statuses       = @{$statuses_ref};
 
-        # print Dumper $statuses_ref;
-        print TIMELINE_DUMPER ( Data::Dumper::Dumper($statuses_ref) );
+        my $data_dumper = Data::Dumper->new([\@statuses], [qw (statuses)]);
+        print TIMELINE_DUMPER ( $data_dumper->Dump);
         foreach my $status (@$statuses_ref) {
             $max_id = $status->{id_str};
 
@@ -188,9 +189,11 @@ if ( $statuses_count != 0 ) {
             include_rts         => $include_rts
         }
     );
+    
+    @statuses       = @{$statuses_ref};
 
-    # print Dumper $statuses_ref;
-    print TIMELINE_DUMPER ( Data::Dumper::Dumper($statuses_ref) );
+    my $data_dumper = Data::Dumper->new([\@statuses], [qw (statuses)]);
+    print TIMELINE_DUMPER ( $data_dumper->Dump);
     foreach my $status (@$statuses_ref) {
         $max_id = $status->{id_str};
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -238,7 +238,7 @@ oauth_desktop.pl [-screen_name] [screen name]
 
 -man       Displays POD and exits.
 -usage     Displays POD and exits.
--update    Displays the Team Explorer command to retrieve the latest update from codeplex.com
+-update    Displays the git fetch from github.com command.
 
 =head1 DESCRIPTION
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -33,6 +33,7 @@ print "Licensed under the Apache License, Version 2.0\n\n";
 
 # Command line arguements
 my $screen_name = "cmlh";
+# TODO since_id i.e. https://dev.twitter.com/docs/working-with-timelines
 
 # Command line meta-options
 my $usage  = 0;

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -18,6 +18,11 @@ use Data::Dumper;
 my $VERSION = "0.001";
 $VERSION = eval $VERSION;
 
+print "\n\"oauth_desktop\" Alpha v$VERSION\n";
+print "\n";
+print "Copyright 2013 Christian Heinrich and Marc Mims\n";
+print "Licensed under the Apache License, Version 2.0\n\n";
+
 # Command line arguements
 my $screen_name = "cmlh";
 

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -1,4 +1,7 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
+# The above shebang is for "perlbrew", otherwise use /usr/bin/perl or the file path quoted for "which perl"
+#
+# Please refer to the Plain Old Documentation (POD) at the end of this Perl Script for further information
 #
 # Net::Twitter - OAuth desktop app example
 #

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -28,7 +28,7 @@ $VERSION = eval $VERSION;
 
 print "\n\"oauth_desktop\" Alpha v$VERSION\n";
 print "\n";
-print "Copyright 2013 Christian Heinrich and Marc Mims\n";
+print "Copyright 2013, 2014 Christian Heinrich and Marc Mims\n";
 print "Licensed under the Apache License, Version 2.0\n\n";
 
 # Command line arguements
@@ -319,4 +319,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. 
 
-Copyright 2013 Christian Heinrich
+Copyright 2013, 2014 Christian Heinrich

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -15,7 +15,8 @@ use Data::Dumper;
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments;
 
-my $VERSION = '1.0.1';
+my $VERSION = "0.001";
+$VERSION = eval $VERSION;
 
 # Command line arguements
 my $screen_name = "cmlh";

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -30,6 +30,11 @@ my (undef, undef, $datafile) = File::Spec->splitpath($0);
 $datafile =~ s/\..*/.dat/;
 
 my $nt = Net::Twitter->new(traits => [qw/API::RESTv1_1/], %consumer_tokens);
+
+# my $ua = $nt->ua;
+# 127.0.0.1:8080 for http://portswigger.net/burp/help/proxy_using.html
+# $ua->proxy(['http', 'https'] => 'http://127.0.0.1:8080');
+
 my $access_tokens = eval { retrieve($datafile) } || [];
 
 if ( @$access_tokens ) {

--- a/examples/oauth_desktop.pl
+++ b/examples/oauth_desktop.pl
@@ -14,6 +14,7 @@ use Data::Dumper;
 use YAML::XS;    # TODO Refactor with YAML::Tiny
 
 # use utf8; applied within YAML::XS
+# TODO use JSON;
 
 # #CONFIGURATION Remove "#" for Smart::Comments
 # use Smart::Comments '####','###';


### PR DESCRIPTION
@semifor,

I just thought I would send you a pull request in relation to my recent progress with oauth_desktop.pl.

The modifications that I have made so far are documented within https://github.com/cmlh/Net-Twitter/commits/master/examples/oauth_desktop.pl

The remaining modification to be completed are highlighted as TODO (perl) comments:
* JSON output of each tweet (added support for YAML and Data::Dumper already).
* Leverage since_id to retrieve latest tweets over time i.e. https://dev.twitter.com/docs/working-with-timelines
* If the PIN is incorrect then re-enter PIN during the initial OAuth request.
* Support Twitter API v1.1 Rate Limiting (dependency on merge of two existing Net::Twitter Pull Requests)
* Display a progress bar implementing $statuses_count minus $count
* Refactor duplicable code as sub()

Please reject this pull request if you believe these would over complicate the Net::Twitter example? 
