### PR TITLE
Always use https on api.twitter.com

### DIFF
--- a/lib/Net/Twitter/Role/API/Lists.pm
+++ b/lib/Net/Twitter/Role/API/Lists.pm
@@ -98,19 +98,13 @@ See L<Net::Twitter> for full documentation.
 
 =cut
 
-has lists_api_url => ( isa => 'Str', is => 'rw', default => 'http://api.twitter.com/1' );
+has lists_api_url => ( isa => 'Str', is => 'rw', default => 'https://api.twitter.com/1' );
 
 base_url     'lists_api_url';
 authenticate 1;
 
 our $DATETIME_PARSER = DateTime::Format::Strptime->new(pattern => '%a %b %d %T %z %Y');
 datetime_parser $DATETIME_PARSER;
-
-after BUILD => sub {
-    my $self = shift;
-
-    $self->{lists_api_url} =~ s/^http:/https:/ if $self->ssl;
-};
 
 twitter_api_method legacy_create_list => (
     path        => ':user/lists',

--- a/lib/Net/Twitter/Role/API/REST.pm
+++ b/lib/Net/Twitter/Role/API/REST.pm
@@ -9,7 +9,7 @@ requires qw/ua username password credentials/;
 
 with 'Net::Twitter::Role::API::Upload';
 
-has apiurl          => ( isa => 'Str', is => 'ro', default => 'http://api.twitter.com/1'  );
+has apiurl          => ( isa => 'Str', is => 'ro', default => 'https://api.twitter.com/1'  );
 has apihost         => ( isa => 'Str', is => 'ro', lazy => 1, builder => '_build_apihost' );
 has apirealm        => ( isa => 'Str', is => 'ro', default => 'Twitter API'               );
 
@@ -17,12 +17,6 @@ sub _build_apihost {
     my $uri = URI->new(shift->apiurl);
     join ':', $uri->host, $uri->port;
 }
-
-after BUILD => sub {
-    my $self = shift;
-
-    $self->{apiurl} =~ s/^http:/https:/ if $self->ssl;
-};
 
 base_url     'apiurl';
 authenticate 1;

--- a/lib/Net/Twitter/Role/API/RESTv1_1.pm
+++ b/lib/Net/Twitter/Role/API/RESTv1_1.pm
@@ -8,7 +8,7 @@ use URI;
 # API v1.1 incorporates the Search and Upload APIs
 excludes map "Net::Twitter::Role::$_", qw/API::Search API::Upload Net::Twitter::Role::RateLimit/;
 
-has apiurl          => ( isa => 'Str', is => 'ro', default => 'http://api.twitter.com/1.1'  );
+has apiurl          => ( isa => 'Str', is => 'ro', default => 'https://api.twitter.com/1.1'  );
 has apihost         => ( isa => 'Str', is => 'ro', lazy => 1, builder => '_build_apihost' );
 has apirealm        => ( isa => 'Str', is => 'ro', default => 'Twitter API'               );
 
@@ -16,12 +16,6 @@ sub _build_apihost {
     my $uri = URI->new(shift->apiurl);
     join ':', $uri->host, $uri->port;
 }
-
-after BUILD => sub {
-    my $self = shift;
-
-    $self->{apiurl} =~ s/^http:/https:/ if $self->ssl;
-};
 
 base_url     'apiurl';
 authenticate 1;

--- a/t/40_nt_subclasses.t
+++ b/t/40_nt_subclasses.t
@@ -16,7 +16,7 @@ sub does_legacy_roles {
 my $nt = Net::Twitter::Search->new;
 does_legacy_roles($nt);
 like  $nt->apiurl,   qr/twitter/,     'twitter url';
-is    $nt->apihost, 'api.twitter.com:80', 'twitter host';
+is    $nt->apihost, 'api.twitter.com:443', 'twitter host';
 
 $nt = Net::Twitter::OAuth->new(consumer_key => 'key', consumer_secret => 'secret');
 does_legacy_roles($nt);


### PR DESCRIPTION
This addresses issue #37.

The ssl option still exists since search.twitter.com and upload.twitter.com still both support http.

For requests that call api.twitter.com, https will always be used regardless of whether ssl is set or not.
