### PR TITLE
Adding twitter_error_text function

### DIFF
--- a/lib/Net/Twitter/Error.pm
+++ b/lib/Net/Twitter/Error.pm
@@ -30,28 +30,44 @@ sub error {
     # Don't walk on $@
     local $@;
 
-    # Twitter does not return a consistent error structure, so we have to
-    # try each known (or guessed) variant to find a suitable message...
-    my $error = $self->has_twitter_error && do {
-        my $e = $self->twitter_error;
-
-        # the newest: array of errors
-        try { exists $e->{errors} && exists $e->{errors}[0] && exists $e->{errors}[0]{message}
-            && $e->{errors}[0]{message} }
-
-        # it's single error variant
-        || try { exists $e->{error} && exists $e->{error}{message} && $e->{error}{message} }
-
-        # or maybe it's not that deep (documentation would be helpful, here, Twitter!)
-        || try { exists $e->{message} && $e->{message} }
-
-        # the original error structure
-        || try { exists $e->{error} && $e->{error} }
-    } || $self->http_response->status_line;
+    my $error = $self->has_twitter_error && $self->twitter_error_text
+      || $self->http_response->status_line;
 
     my ($location) = $self->stack_trace->frame(0)->as_string =~ /( at .*)/;
     return $self->_stringified($error . ($location || ''));
 }
+
+sub twitter_error_text {
+    my $self = shift;
+    # Twitter does not return a consistent error structure, so we have to
+    # try each known (or guessed) variant to find a suitable message...
+
+    return '' unless $self->has_twitter_error;
+    my $e = $self->twitter_error;
+
+    # the newest: array of errors
+    return try {
+             exists $e->{errors}
+          && exists $e->{errors}[0]
+          && exists $e->{errors}[0]{message}
+          && $e->{errors}[0]{message};
+    }
+
+    # it's single error variant
+      || try {
+        exists $e->{error}
+          && exists $e->{error}{message}
+          && $e->{error}{message};
+    }
+
+    # or maybe it's not that deep (documentation would be helpful, here, Twitter!)
+      || try { exists $e->{message} && $e->{message} }
+
+    # the original error structure
+      || try { exists $e->{error} && $e->{error} }
+      || '';
+}
+
 
 sub twitter_error_code {
     my $self = shift;
@@ -139,7 +155,12 @@ Returns true if the object contains a Twitter error HASH.
 =item error
 
 Returns the C<error> value from the C<twitter_error> HASH ref if there is one.
-Otherwise, it returns the string "[unknown]".
+Otherwise, it returns the string "[unknown]". Includes a stack trace.
+
+=item twitter_error_text
+
+Returns the C<error> value from the C<twitter_error> HASH ref if there is one.
+Otherwise, returns an empty string
 
 =item twitter_error_code
 

--- a/t/twitter_error.t
+++ b/t/twitter_error.t
@@ -1,7 +1,7 @@
 #!perl
 use warnings;
 use strict;
-use Test::More tests => 4;
+use Test::More tests => 8;
 use Net::Twitter::Error;
 use HTTP::Response;
 
@@ -15,6 +15,7 @@ use HTTP::Response;
     );
 
     like $e, qr/Something wicked/, 'old school twitter error';
+    is $e->twitter_error_text, 'Something wicked', 'twitter_error_text for old school twitter error';
 }
 
 {
@@ -27,6 +28,7 @@ use HTTP::Response;
     );
 
     like $e, qr/Something wicked/, 'twitter error with message/code';
+    is $e->twitter_error_text, 'Something wicked', 'twitter_error_text for twitter error with message/code';
 }
 
 {
@@ -39,6 +41,7 @@ use HTTP::Response;
     );
 
     like $e, qr/Something wicked/, 'twitter array of errors';
+    is $e->twitter_error_text, 'Something wicked', 'twitter_error_text for twitter array of errors';
 }
 
 {
@@ -49,5 +52,6 @@ use HTTP::Response;
         http_response => $res,
     );
 
+    is $e->twitter_error_text, '', 'twitter_error_text is empty string';
     like $e, qr/Bad Request/, 'twitter array of errors';
 }


### PR DESCRIPTION
Adding a twitter_error_text function to Net::Twitter::Error.

Returns the error text returned from twitter, without a stack trace 'at line...' bit appended to the end of the string. Modified error() to get the error text from twitter_error_text()

A couple of things I noticed in the pod for error(), didn't want to mess with your docs too much:
-POD for error() mentions that it returns the string '[unknown]' but I don't see this happening in code.
-error() falls back to the HTTP status line, but that isn't mentioned in the POD

Thanks!
