### PR TITLE
use HTTP::Request::Common when possible, put query params in content, co...

### DIFF
--- a/lib/Net/Twitter/Core.pm
+++ b/lib/Net/Twitter/Core.pm
@@ -182,8 +182,13 @@ sub _prepare_request {
     my %natural_args = $self->_natural_args($args);
 
     $self->_encode_args(\%natural_args);
-
-    if ( $http_method =~ /^(?:GET|DELETE|PUT)$/ ) {
+    if( $http_method eq 'PUT' ) {
+        $msg = PUT(
+            $uri,
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            Content        => $self->_query_string_for( \%natural_args ) );
+    }
+    elsif ( $http_method =~ /^(?:GET|DELETE)$/ ) {
         $uri->query($self->_query_string_for(\%natural_args));
         $msg = HTTP::Request->new($http_method, $uri);
     }


### PR DESCRIPTION
...ntent-type added

Re: https://dev.twitter.com/docs/api/advertising/updates/20140326#Require_PUT_to_include_the_Content-Length_Header

"We have made a change across of Twitter inbound traffic that now enforces the behavior in the spec around PUTs. This means we require the Content-Length header for PUTs now. We'd like to remind partners that we suggest that **all PUTs pass the request parameters within the body of the request.**

If you encounter this error, you'll receive a HTTP 411 - Length Required error response from the API.'

Emphasis added, in actuality putting the params in as Query params will result in a 401. Also, leaving out the content-type will result in a 401.
