### PR TITLE
s/JSON/JSON::MaybeXS/

### DIFF
--- a/lib/Net/Twitter.pm
+++ b/lib/Net/Twitter.pm
@@ -2,7 +2,7 @@ package Net::Twitter;
 
 use Moose;
 use Carp::Clan qw/^(?:Net::Twitter|Moose|Class::MOP)/;
-use JSON;
+use JSON::MaybeXS;
 use Net::Twitter::Core;
 use Digest::SHA qw/sha1_hex/;
 use Class::Load ();
@@ -86,7 +86,7 @@ sub _create_anon_class {
             my $t = shift @t;
             if ( ref $t[0] eq 'HASH' ) {
                 my $params = shift @t;
-                my $sig = sha1_hex(JSON->new->utf8->encode($params));
+                my $sig = sha1_hex(JSON::MaybeXS->new->utf8->encode($params));
                 my $sn  = $serial_for_params{$sig} ||= ++$serial_number;
                 $t .= "_$sn";
             }

--- a/lib/Net/Twitter/Core.pm
+++ b/lib/Net/Twitter/Core.pm
@@ -5,7 +5,7 @@ package Net::Twitter::Core;
 use 5.008001;
 use Moose;
 use Carp::Clan qw/^(?:Net::Twitter|Moose|Class::MOP)/;
-use JSON;
+use JSON::MaybeXS;
 use URI::Escape;
 use HTTP::Request::Common;
 use Net::Twitter::Error;
@@ -36,7 +36,7 @@ has clienturl       => ( isa => 'Str', is => 'ro', default => 'http://search.cpa
 has _base_url       => ( is => 'rw' ); ### keeps role composition from bitching ??
 has _json_handler   => (
     is      => 'rw',
-    default => sub { JSON->new->utf8 },
+    default => sub { JSON::MaybeXS->new->utf8 },
     handles => { from_json => 'decode' },
 );
 

--- a/t/20_exceptions.t
+++ b/t/20_exceptions.t
@@ -3,7 +3,7 @@ use warnings;
 use strict;
 use Test::More;
 use Test::Fatal;
-use JSON qw/to_json/;
+use JSON::MaybeXS qw/encode_json/;
 use lib qw(t/lib);
 use Net::Twitter;
 
@@ -20,7 +20,7 @@ my $nt = Net::Twitter->new(
 my $t = TestUA->new(1, $nt->ua);
 
 my $response = HTTP::Response->new(404, 'Not Found');
-$response->content(to_json({
+$response->content(encode_json({
     request => '/direct_messages/destroy/456.json',
     error   => 'No direct message with that ID found.',
 }));

--- a/t/50_inflate_objects.t
+++ b/t/50_inflate_objects.t
@@ -3,7 +3,7 @@ use warnings;
 use strict;
 use Scalar::Util qw/blessed/;
 use Test::More;
-use JSON qw/to_json/;
+use JSON::MaybeXS qw /encode_json/;
 use lib qw(t/lib);
 
 eval 'use TestUA';
@@ -24,7 +24,7 @@ my $dt = DateTime->now;
 $dt->subtract(minutes => 6);
 
 my $t = TestUA->new(1, $nt->ua);
-$t->response->content(to_json([{
+$t->response->content(encode_json([{
     text => 'Hello, twittersphere!',
     user => {
        screen_name => 'net_twitter',
@@ -43,7 +43,7 @@ is     $object->relative_created_at, '6 minutes ago', 'relative_created_at';
 is     $object->user->screen_name,   'net_twitter',   'nested objects';
 
 # make sure we don't co-mingle our object methods
-$t->response->content(to_json({
+$t->response->content(encode_json({
     foo => 'foo',
     bar => 'bar',
     baz => 'and of course, baz',

--- a/t/51_rate_limit.t
+++ b/t/51_rate_limit.t
@@ -2,7 +2,7 @@
 use warnings;
 use strict;
 use Test::More;
-use JSON qw/to_json/;
+use JSON::MaybeXS qw/encode_json/;
 use lib qw(t/lib);
 use Net::Twitter;
 
@@ -13,7 +13,7 @@ my $nt = Net::Twitter->new(ssl => 0, traits => [qw/API::REST RateLimit/]);
 
 my $reset = time + 1800;
 my $t = TestUA->new(1, $nt->ua);
-$t->response->content(to_json({
+$t->response->content(encode_json({
     remaining_hits        => 75,
     reset_time_in_seconds => $reset,
     hourly_limit          => 150,
@@ -33,7 +33,7 @@ ok   $until > 890 && $until < 910, 'until_rate(2.0) is about 900';
 
 
 # test clock mismatch
-$t->response->content(to_json({
+$t->response->content(encode_json({
     remaining_hits        => 10,
     reset_time_in_seconds => $nt->_rate_limit_status->{rate_reset} = time - 10,
     hourly_limit          => 150,

--- a/t/51_since.t
+++ b/t/51_since.t
@@ -4,7 +4,7 @@ use strict;
 use Try::Tiny;
 use Scalar::Util qw/blessed/;
 use Test::More;
-use JSON qw/to_json/;
+use JSON::MaybeXS qw/encode_json/;
 use lib qw(t/lib);
 
 eval 'use TestUA';
@@ -25,7 +25,7 @@ my $dt = DateTime->now;
 $dt->subtract(minutes => 6);
 
 my $t = TestUA->new(1, $nt->ua);
-$t->response->content(to_json([
+$t->response->content(encode_json([
     {
         text => 'Hello, twittersphere!',
         id => 1234,

--- a/t/auto-cursor.t
+++ b/t/auto-cursor.t
@@ -3,10 +3,10 @@ use warnings;
 use strict;
 use Test::More;
 use Net::Twitter;
-use JSON qw/to_json/;
+use JSON::MaybeXS qw/encode_json/;
 use HTTP::Response;
 
-my $json_result = to_json({ ids => ['test'], next_cursor => 1 });
+my $json_result = encode_json({ ids => ['test'], next_cursor => 1 });
 sub mock_ua {
     my $nt = shift;
 
@@ -25,7 +25,7 @@ sub mock_ua {
     my $nt_with_max_calls_4 = Net::Twitter->new(ssl => 0, traits => ['API::REST',  AutoCursor => { max_calls => 4 }]);
     my $class_for_max_calls_4 = ref $nt_with_max_calls_4;
 
-    my $json_result = to_json({ ids => ['test'], next_cursor => 1 });
+    my $json_result = encode_json({ ids => ['test'], next_cursor => 1 });
 
     mock_ua($_) for $nt_with_max_calls_2, $nt_with_max_calls_4;
 


### PR DESCRIPTION
Fixes #59 

I was actually having trouble testing this:

```
Olafs-MacBook-Pro:Net-Twitter olaf$ dzil test
[DZ] building distribution under .build/5Loo6PgKtC for installation
[Run::BeforeBuild] executing: NET_TWITTER_NO_TRENDS_WARNING=1 /usr/bin/perl -I/lib src/build.pl 4.01010 'src/net-twitter-pod.tt2' 'lib/Net/Twitter.pod'
[Run::BeforeBuild] executing: pod2text 'lib/Net/Twitter.pod' 'README'
[DZ] beginning to build Net-Twitter
[PodVersion] lib/Net/Twitter.pod already has a VERSION section in POD
[ExtraTests] rewriting author test xt/author/pod-syntax.t
[ExtraTests] rewriting author test xt/author/pod-coverage.t
[DZ] guessing dist's main_module is lib/Net/Twitter.pm
Can't call method "content" on an undefined value at /Users/olaf/perl5/lib/perl5/Dist/Zilla/Plugin/ModuleBuild.pm line 221.
```

It looks like it's looking for a `Build.PL` at this point, which doesn't exist on my end.  I get this error on my branch as well as on master.  I'm up to date with the various dzil deps.

So, this allows me to run the tests:

```
diff --git a/dist.ini b/dist.ini
index 34f6ff1..83063ee 100644
--- a/dist.ini
+++ b/dist.ini
@@ -38,7 +38,7 @@ directory = examples

 [PruneFiles]
 filename = dist.ini
-filename = Build.PL
+;filename = Build.PL
 filename = README.md
 match = ^nytprof.*
 match = ^perl5
```

There are 3 failing tests for me, but they're also failing on the master branch:

```
t/10_net-twitter-regression.t (Wstat: 512 Tests: 5 Failed: 1)
  Failed test:  5
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
t/12_identica.t              (Wstat: 512 Tests: 1 Failed: 0)
  Non-zero exit status: 2
  Parse errors: Bad plan.  You planned 5 tests but ran 1.
t/15_subclass.t              (Wstat: 0 Tests: 27 Failed: 0)
  TODO passed:   13-16, 18
Files=36, Tests=2950, 29 wallclock secs ( 0.45 usr  0.12 sys + 25.08 cusr  2.07 csys = 27.72 CPU)
Result: FAIL
Failed 2/36 test programs. 1/2950 subtests failed.
```