### PR TITLE
tweak build configs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,9 +17,7 @@ bugtracker = http://github.com/semifor/Net-Twitter/issues
 [MetaYAML]
 [License]
 [ExtraTests]
-[ExecDir]
-[ShareDir]
-[ModuleBuild]
+[MakeMaker]
 [Manifest]
 [TestRelease]
 [ConfirmRelease]
@@ -37,7 +35,6 @@ directory = src
 directory = examples
 
 [PruneFiles]
-filename = dist.ini
 filename = README.md
 match = ^nytprof.*
 match = ^perl5
@@ -54,7 +51,7 @@ LWP::Protocol::https = 0
 IO::Socket::SSL = >=2.005
 
 [Prereqs / TestRequires]
-Test::Simple = 0.98
+Test::More = 0.98
 Test::Fatal = 0
 
 [PodSyntaxTests]


### PR DESCRIPTION
- remove unused plugins ExecDir and ShareDir (no script, bin, share dirs present)
- produce a Makefile.PL instead of Build.PL (Module::Build is best
  avoided when possible)
- keep dist.ini in shipped dist (makes it possible to use grep.cpan.me
  to find certain configs in use)