### PR TITLE
remove extraneous arguments to use_ok

### DIFF
--- a/t/21_wraperror.t
+++ b/t/21_wraperror.t
@@ -11,7 +11,7 @@ BEGIN {
 
     plan tests => 12;
 
-    use_ok 'Net::Twitter', qw/Legacy/;
+    use_ok 'Net::Twitter';
 }
 
 my $nt  = Net::Twitter->new(ssl => 0, username => 'me', password => 'secret');

--- a/t/30_legacy.t
+++ b/t/30_legacy.t
@@ -11,7 +11,7 @@ BEGIN {
 
     plan tests => 5;
 
-    use_ok 'Net::Twitter', qw/Legacy/;
+    use_ok 'Net::Twitter';
 }
 
 my $nt  = Net::Twitter->new(ssl => 0, username => 'me', password => 'secret');


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.